### PR TITLE
Fixes #17 : Add a ChangeInterface

### DIFF
--- a/src/AbstractChange.php
+++ b/src/AbstractChange.php
@@ -17,7 +17,7 @@ namespace Totem;
  * @author Baptiste Clavié <clavie.b@gmail.com>
  * @author Rémy Gazelot <rgazelot@gmail.com>
  */
-abstract class AbstractChange
+abstract class AbstractChange implements ChangeInterface
 {
     /** old state */
     private $old;

--- a/src/ChangeInterface.php
+++ b/src/ChangeInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of the Totem package
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ *
+ * @copyright Baptiste Clavié <clavie.b@gmail.com>
+ * @license   http://www.opensource.org/licenses/MIT-License MIT License
+ */
+
+namespace Totem;
+
+/**
+ * Represent a change in a data, with both values (before and after it was modified)
+ *
+ * @author Baptiste Clavié <clavie.b@gmail.com>
+ */
+interface ChangeInterface
+{
+    /** @return mixed the data before it was changed */
+    public function getOld();
+
+    /** @return mixed the data after it was changed */
+    public function getNew();
+}
+


### PR DESCRIPTION
Fixes #17 : Now, a ChangeInterface is available to not be delimited by an `AbtractChange` but something more open (like, in my case, having to extend `Set` and allow to fetch the "old" data and the "new" one)
