### PR TITLE
Shippable Integration

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -3,7 +3,7 @@
 #
 
 src_dir: src
-service_name: travis-ci
-coverage_clover: clover.xml
+service_name: shippable
+coverage_clover: shippable/clover.xml
 json_path: coveralls-upload.json
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,29 @@
+language: php
+
+php:
+    - 5.4
+    - 5.5
+    - 5.6
+    - hhvm
+
+matrix:
+  allow_failures:
+      - php: hhvm
+
+git:
+    submodules: false
+
+before_script:
+    - mkdir -p shippable/codecoverage
+    - mkdir -p shippable/testresults
+    - composer self-update
+    - composer install --prefer-source -o
+
+script:
+    - bin/phpunit --log-junit "shippable/testresults/junit.xml" --coverage-clover "clover.xml" --coverage-xml "shippable/codecoverage" --coverage-text
+
+after_script:
+    - bin/coveralls
+
+notifications:
+    email: false


### PR DESCRIPTION
Because [Shippable](http://www.shippable.com) is a CI service that is cooler (and faster) than Travis-CI.

But it suffers some problems at the moment (coveralls integration is not complete, and the tests results are somewhat disappointing even though it is said that everything is fine). And also because I do not have enough rights on the repo right now to use Shippable.

So the point is, this should not be merged before everything is settled.