### PR TITLE
Use PropertyPath instead of a wild guess for CollectionSnapshot

### DIFF
--- a/test/SetTest.php
+++ b/test/SetTest.php
@@ -187,13 +187,13 @@ class SetTest extends \PHPUnit_Framework_TestCase
         $old = $new = [['foo' => 'bar', 'baz' => 'fubar'], ['foo' => 'baz', 'baz' => 'fubar']];
         $new[0]['baz'] = 'fubaz';
 
-        $old = new CollectionSnapshot($old, 'foo');
-        $new = new CollectionSnapshot($new, 'foo');
+        $old = new CollectionSnapshot($old, '[foo]');
+        $new = new CollectionSnapshot($new, '[foo]');
 
         $set = new Set;
         $set->compute($old, $new);
 
-        $this->assertContainsOnly('integer',array_keys(iterator_to_array($set)));
+        $this->assertContainsOnly('integer', array_keys(iterator_to_array($set)));
     }
 
     /** @dataProvider unaffectedSnapshotComputerProvider */
@@ -209,8 +209,8 @@ class SetTest extends \PHPUnit_Framework_TestCase
     {
         $old = ['foo' => 'bar', 'baz' => 'fubar'];
 
-        return [[new CollectionSnapshot([$old], 'foo'), new ArraySnapshot($old)],
-                [new ArraySnapshot($old), new CollectionSnapshot([$old], 'foo')],
+        return [[new CollectionSnapshot([$old], '[foo]'), new ArraySnapshot($old)],
+                [new ArraySnapshot($old), new CollectionSnapshot([$old], '[foo]')],
                 [new ArraySnapshot($old), new ArraySnapshot(array_merge($old, ['baz' => 'fubaz']))]];
     }
 }

--- a/test/Snapshot/CollectionSnapshotTest.php
+++ b/test/Snapshot/CollectionSnapshotTest.php
@@ -82,7 +82,7 @@ class CollectionSnapshotTest extends PHPUnit_Framework_TestCase
             $options['snapshotClass'] = 'Totem\\Snapshot';
         }
 
-        $snapshot = new CollectionSnapshot([['foo' => 'bar', 'baz' => 'fubar']], 'foo', $options);
+        $snapshot = new CollectionSnapshot([['foo' => 'bar', 'baz' => 'fubar']], '[foo]', $options);
 
         $refl = new ReflectionProperty('Totem\\AbstractSnapshot', 'data');
         $refl->setAccessible(true);
@@ -103,13 +103,13 @@ class CollectionSnapshotTest extends PHPUnit_Framework_TestCase
      */
     public function testOriginalKeyNotFound()
     {
-        $snapshot = new CollectionSnapshot([['foo' => 'bar']], 'foo');
+        $snapshot = new CollectionSnapshot([['foo' => 'bar']], '[foo]');
         $snapshot->getOriginalKey('baz');
     }
 
     public function testOriginalKey()
     {
-        $snapshot = new CollectionSnapshot([['foo' => 'bar']], 'foo');
+        $snapshot = new CollectionSnapshot([['foo' => 'bar']], '[foo]');
 
         $this->assertSame(0, $snapshot->getOriginalKey('bar'));
     }


### PR DESCRIPTION
Fixes #28, and also allows to use more complex keys than what it was before (like `[key][subkey]`, `property.sub`, `property.sub[key]`, ... etc)
