### PR TITLE
Remove all traces of reflection in ObjectSnapshot

### DIFF
--- a/src/Snapshot/ObjectSnapshot.php
+++ b/src/Snapshot/ObjectSnapshot.php
@@ -46,8 +46,7 @@ class ObjectSnapshot extends AbstractSnapshot
         $class = get_class($object);
 
         foreach ($export as $property => $value) {
-            $property = str_replace("\x00*\x00", '', $property); // protected property
-            $property = str_replace("\x00{$class}\x00", '', $property); // private property
+            $property = str_replace(["\x00*\x00", "\x00{$class}\x00"], '', $property); // not accessible properties
 
             $this->data[$property] = $value;
         }

--- a/src/Snapshot/ObjectSnapshot.php
+++ b/src/Snapshot/ObjectSnapshot.php
@@ -41,18 +41,15 @@ class ObjectSnapshot extends AbstractSnapshot
 
         $this->raw = $object;
         $this->oid = spl_object_hash($object);
-        $refl      = new ReflectionObject($object);
 
-        if (method_exists('\\ReflectionObject', 'isCloneable') && $refl->isCloneable()) {
-            $this->raw = clone $object;
-        }
+        $export = (array) $object;
+        $class = get_class($object);
 
-        /** @var \ReflectionProperty $reflProperty */
-        foreach ($refl->getProperties() as $reflProperty) {
-            $reflProperty->setAccessible(true);
-            $value = $reflProperty->getValue($object);
+        foreach ($export as $property => $value) {
+            $property = str_replace("\x00*\x00", '', $property); // protected property
+            $property = str_replace("\x00{$class}\x00", '', $property); // private property
 
-            $this->data[$reflProperty->getName()] = $value;
+            $this->data[$property] = $value;
         }
 
         parent::normalize();

--- a/test/Snapshot/ObjectSnapshotTest.php
+++ b/test/Snapshot/ObjectSnapshotTest.php
@@ -58,9 +58,43 @@ class ObjectSnapshotTest extends PHPUnit_Framework_TestCase
 
     public function deepProvider()
     {
-        return [[(object) ['bar' => 'baz']],
-                [['bar' => 'baz']],
-                ['fubar']];
+        return [
+            'with a sub-object' => [(object) ['bar' => 'baz']],
+            'with a sub-array' => [['bar' => 'baz']],
+            'with a scalar' => ['fubar']
+        ];
+    }
+
+    public function testExportAllProperties()
+    {
+        $snapshot = new ObjectSnapshot(new Foo('foo', 'bar', 'baz'));
+        $data = $snapshot->getComparableData();
+
+        $this->assertCount(3, $data);
+
+        $this->assertArrayHasKey('foo', $data);
+        $this->assertArrayHasKey('bar', $data);
+        $this->assertArrayHasKey('baz', $data);
+
+        $this->assertSame('foo', $data['foo']);
+        $this->assertSame('bar', $data['bar']);
+        $this->assertSame('baz', $data['baz']);
     }
 }
+
+// todo in php7 : use anon class !
+class Foo
+{
+    public $foo;
+    protected $bar;
+    private $baz;
+
+    public function __construct($foo, $bar, $baz)
+    {
+        $this->foo = $foo;
+        $this->bar = $bar;
+        $this->baz = $baz;
+    }
+}
+
 

--- a/test/Snapshot/ObjectSnapshotTest.php
+++ b/test/Snapshot/ObjectSnapshotTest.php
@@ -48,23 +48,6 @@ class ObjectSnapshotTest extends PHPUnit_Framework_TestCase
         new ObjectSnapshot([]);
     }
 
-    /**
-     * @dataProvider deepProvider
-     */
-    public function testDeepConstructor($value)
-    {
-        new ObjectSnapshot((object) ['foo' => $value]);
-    }
-
-    public function deepProvider()
-    {
-        return [
-            'with a sub-object' => [(object) ['bar' => 'baz']],
-            'with a sub-array' => [['bar' => 'baz']],
-            'with a scalar' => ['fubar']
-        ];
-    }
-
     public function testExportAllProperties()
     {
         $snapshot = new ObjectSnapshot(new Foo('foo', 'bar', 'baz'));
@@ -79,6 +62,22 @@ class ObjectSnapshotTest extends PHPUnit_Framework_TestCase
         $this->assertSame('foo', $data['foo']);
         $this->assertSame('bar', $data['bar']);
         $this->assertSame('baz', $data['baz']);
+    }
+
+    public function testDeepConstructor()
+    {
+        $object = new Foo(
+            (object) ['foo' => 'bar'], // object
+            ['baz' => 'fubar'], // array
+            'fubaz' // scalar
+        );
+
+        $snapshot = new ObjectSnapshot($object);
+        $data = $snapshot->getComparableData();
+
+        $this->assertInstanceOf('Totem\\Snapshot\\ObjectSnapshot', $data['foo']);
+        $this->assertInstanceOf('Totem\\Snapshot\\ArraySnapshot', $data['bar']);
+        $this->assertNotInstanceOf('Totem\\AbstractSnapshot', $data['baz']);
     }
 }
 


### PR DESCRIPTION
Merry christmas @krichprollsch and @lunika, if this works as it should... :heart: 

Basically, removing all traces or dependencies towards Reflection for an ObjectSnapshot. Need to create more tests though with actual objects (see https://gist.github.com/Taluu/2ed4d1d71d5c0db291c4#gistcomment-1657274)

- [x] Remove Reflection stuff
- [x] Add some tests for private / protected properties

It's a little bit hackish though, even though it is still *far* more optimized like this.